### PR TITLE
Add jasper as a direct dependency 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,12 +27,10 @@ install:
       bash $MINICONDA_FILE -b
 
       export PATH=/Users/travis/miniconda3/bin:$PATH
-
-      conda config --set show_channel_urls true
-      conda update --yes conda
-      conda install --yes conda-build=1.20.0 jinja2 anaconda-client
       conda config --add channels conda-forge
-      
+      conda config --set show_channel_urls true
+      conda install --yes --quiet conda-forge-build-setup
+      source run_conda_forge_build_setup
 
 script:
   - conda build ./recipe

--- a/README.md
+++ b/README.md
@@ -3,11 +3,11 @@ About pynio
 
 Home: http://www.pyngl.ucar.edu/Nio.shtml
 
-Package license: BSD-3-clause
+Package license: BSD 3-clause
 
 Feedstock license: BSD 3-Clause
 
-Summary: PyNIO is a multi-format data I/O package with a NetCDF-style interface
+Summary: PyNIO is a multi-format data I/O package with a NetCDF-style interface.
 
 
 
@@ -38,7 +38,7 @@ About conda-forge
 
 conda-forge is a community-led conda channel of installable packages.
 In order to provide high-quality builds, the process has been automated into the
-conda-forge GitHub organization. The conda-forge organization contains one repository 
+conda-forge GitHub organization. The conda-forge organization contains one repository
 for each of the installable packages. Such a repository is known as a *feedstock*.
 
 A feedstock is made up of a conda recipe (the instructions on what and how to build
@@ -71,7 +71,7 @@ Current build status
 ====================
 
 Linux: [![Circle CI](https://circleci.com/gh/conda-forge/pynio-feedstock.svg?style=svg)](https://circleci.com/gh/conda-forge/pynio-feedstock)
-OSX: [![TravisCI](https://travis-ci.org/conda-forge/pynio-feedstock.svg?branch=master)](https://travis-ci.org/conda-forge/pynio-feedstock) 
+OSX: [![TravisCI](https://travis-ci.org/conda-forge/pynio-feedstock.svg?branch=master)](https://travis-ci.org/conda-forge/pynio-feedstock)
 Windows: [![AppVeyor](https://ci.appveyor.com/api/projects/status/github/conda-forge/pynio-feedstock?svg=True)](https://ci.appveyor.com/project/conda-forge/pynio-feedstock/branch/master)
 
 Current release info
@@ -92,7 +92,7 @@ install and use.
 
 In order to produce a uniquely identifiable distribution:
  * If the version of a package **is not** being increased, please add or increase
-   the [``build/number``](http://conda.pydata.org/docs/building/meta-yaml.html#build-number-and-string). 
+   the [``build/number``](http://conda.pydata.org/docs/building/meta-yaml.html#build-number-and-string).
  * If the version of a package **is** being increased, please remember to return
    the [``build/number``](http://conda.pydata.org/docs/building/meta-yaml.html#build-number-and-string)
    back to 0.

--- a/ci_support/run_docker_build.sh
+++ b/ci_support/run_docker_build.sh
@@ -14,7 +14,6 @@ config=$(cat <<CONDARC
 
 channels:
  - conda-forge
-
  - defaults # As we need conda-build
 
 conda-build:
@@ -39,9 +38,8 @@ echo "$config" > ~/.condarc
 # A lock sometimes occurs with incomplete builds. The lock file is stored in build_artefacts.
 conda clean --lock
 
-conda update --yes --all
-conda install --yes conda-build
-conda info
+conda install --yes --quiet conda-forge-build-setup
+source run_conda_forge_build_setup
 
 # Embarking on 2 case(s).
     set -x

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -18,6 +18,11 @@ export CPPFLAGS="-I$PREFIX/include $CPPFLAGS"
 export CFLAGS="-D_BSD_SOURCE -D_XOPEN_SOURCE -I$PREFIX/include $CFLAGS"
 
 if [[ $(uname) == Darwin ]]; then
+  export CC=clang
+  export CXX=clang++
+  export MACOSX_DEPLOYMENT_TARGET="10.9"
+  export CXXFLAGS="-stdlib=libc++ $CXXFLAGS"
+  export CXXFLAGS="$CXXFLAGS -stdlib=libc++"
   export LDFLAGS="-headerpad_max_install_names $LDFLAGS"
 fi
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,23 +1,25 @@
-{% set version = "1.5.0" %}
+{% set ver = "1.5.0" %}
 {% set beta = "beta20160623" %}
+{% set version = ver + "_" + beta %}
 
 package:
     name: pynio
     version: {{ version }}
 
 source:
-    fn: pynio-{{ version }}-{{ beta }}.tar.gz
-    url: https://github.com/NCAR/pynio/archive/{{ version }}_{{ beta }}.tar.gz
+    fn: pynio-{{ version }}.tar.gz
+    url: https://github.com/NCAR/pynio/archive/{{ version }}.tar.gz
     sha256: 43411c577e21335d4684f384cbf117b41202f55b49198d1c688fc65703dbff68
 
 build:
-    number: 7
+    number: 8
     skip: True  # [win or py3k]
     detect_binary_files_with_prefix: true
 
 requirements:
     build:
         - python
+        - gcc
         - numpy x.x
         - libnetcdf 4.4.*
         - proj.4
@@ -25,7 +27,7 @@ requirements:
         - g2clib
         - hdfeos2
         - hdfeos5
-        - gcc
+        - jasper
     run:
         - python
         - numpy x.x
@@ -36,7 +38,8 @@ requirements:
         - g2clib
         - hdfeos2
         - hdfeos5
-        - libgcc
+        - jasper
+        - libgfortran
 
 test:
     requires:
@@ -45,14 +48,15 @@ test:
         - Nio
     commands:
         - cd $SRC_DIR/test && nosetests
-        - conda inspect linkages -n _test pynio  # [linux]
+        - conda inspect linkages -n _test pynio
 
 about:
     home: http://www.pyngl.ucar.edu/Nio.shtml
-    license: BSD-3-clause
-    summary: PyNIO is a multi-format data I/O package with a NetCDF-style interface
+    license: BSD 3-clause
+    summary: 'PyNIO is a multi-format data I/O package with a NetCDF-style interface.'
 
 extra:
     recipe-maintainers:
+        - marylhaley
         - ocefpaf
         - jhamman


### PR DESCRIPTION
This PR closes #10 and #11.

PS: The `jinja` variable "beta" was not used to create `version`. Thanks to @marylhaley for noticing this!