### PR TITLE
Pin g2clib

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
     sha256: 43411c577e21335d4684f384cbf117b41202f55b49198d1c688fc65703dbff68
 
 build:
-    number: 8
+    number: 9
     skip: True  # [win or py3k]
     detect_binary_files_with_prefix: true
 
@@ -24,7 +24,7 @@ requirements:
         - libnetcdf 4.4.*
         - proj.4
         - gdal 1.11.*
-        - g2clib
+        - g2clib 1.5.*
         - hdfeos2
         - hdfeos5
         - jasper
@@ -35,7 +35,7 @@ requirements:
         - hdf4
         - proj.4
         - gdal 1.11.*
-        - g2clib
+        - g2clib 1.5.*
         - hdfeos2
         - hdfeos5
         - jasper
@@ -48,7 +48,8 @@ test:
         - Nio
     commands:
         - cd $SRC_DIR/test && nosetests
-        - conda inspect linkages -n _test pynio
+        - conda inspect linkages -n _test pynio  # [not win]
+        - conda inspect objects -n _test pynio  # [osx]
 
 about:
     home: http://www.pyngl.ucar.edu/Nio.shtml


### PR DESCRIPTION
I could not get `pynio` to work with the latest `g2clib 1.6.0`, so I am pinning it here to the `1.5.*` version.

See https://github.com/conda-forge/g2clib-feedstock/pull/9