### PR TITLE
Pin gdal 2.1.x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,9 +9,7 @@ osx_image: xcode6.4
 env:
   matrix:
     
-    - CONDA_NPY=111  CONDA_PY=27
-    - CONDA_NPY=112  CONDA_PY=27
-    - CONDA_NPY=113  CONDA_PY=27
+    - CONDA_PY=27
   global:
     # The BINSTAR_TOKEN secure variable. This is defined canonically in conda-forge.yml.
     - secure: "ic+S+o+y1Wux87xT5BnRTnMGRh/oBI5heNIzsz21hbfsplidJv7ueyg9oqODfEAhUXndvDSZUN9kLiURfA3sSZ/9VFxe7EdtbSmTsRp1+3CYAH5Zp6orrfeLUKzsIbgRKiXzY9xAtr1EM6Jz077propA4buDJPv0GKjWWme/7F448+l/n530+MRPzbuPe5ctM6wxnAiHQGfkiNTnLKkptoB7SZ7q7eZUls3GuKzmUX7dioHdPeJS7rjv/ANWLl164k3OL9KHj0JJuLgPyjjn52UhLuu+yxLtcqAFOzToQ/h0Jj6a1z1dZGEAzdPQHZKVV47M93qydnsrOIJ843ijKSZugAq/mWMAyh7mYSHR+7OaSy6Pq1IbqR8DbBa3x7J3P/iE6SLGY46r0Yp1Z5ocpw5Qz2zBFsc1blUXky8jRUx9C5Cl715rEEunKLlnHiUbcc1wtGbhhYV42mwJTA0/BcAER5brKCIQUS7ADW2Vm8pagCOpIrsQTqPnw3C+mvf3uDwNj2PeGDB9S9BvkyaGH+nhkTduspNOFmpehyAqJU6ghjwf1rvkJx0h+6/rgDHWvcebpM6pt43tE0lAQBQKXAbIkKfDHsC4Wlo1X4ycILkLr+g6pDgmHyhd+w/qrdTOeDo4rs0imNndVodjXTrv7xWLvHks3hduG4JjO9QV6rA="

--- a/ci_support/run_docker_build.sh
+++ b/ci_support/run_docker_build.sh
@@ -57,23 +57,8 @@ conda clean --lock
 conda install --yes --quiet conda-forge-build-setup
 source run_conda_forge_build_setup
 
-# Embarking on 3 case(s).
+# Embarking on 1 case(s).
     set -x
-    export CONDA_NPY=111
-    export CONDA_PY=27
-    set +x
-    conda build /recipe_root --quiet || exit 1
-    upload_or_check_non_existence /recipe_root conda-forge --channel=main || exit 1
-
-    set -x
-    export CONDA_NPY=112
-    export CONDA_PY=27
-    set +x
-    conda build /recipe_root --quiet || exit 1
-    upload_or_check_non_existence /recipe_root conda-forge --channel=main || exit 1
-
-    set -x
-    export CONDA_NPY=113
     export CONDA_PY=27
     set +x
     conda build /recipe_root --quiet || exit 1

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -14,7 +14,7 @@ source:
     - test_opendap2_url.patch
 
 build:
-  number: 15
+  number: 16
   skip: True  # [win or py3k]
   detect_binary_files_with_prefix: true
 
@@ -22,10 +22,10 @@ requirements:
   build:
     - python
     - gcc
-    - numpy x.x
+    - numpy 1.7.*  # [py27]
     - libnetcdf 4.4.*
     - proj4 4.9.3
-    - gdal 2.2.*
+    - libgdal 2.1.*
     - g2clib 1.6.*
     - hdfeos2
     - hdfeos5
@@ -34,11 +34,11 @@ requirements:
     - libuuid  # [osx]
   run:
     - python
-    - numpy x.x
+    - numpy >=1.7  # [py27]
     - libnetcdf 4.4.*
     - hdf4
     - proj4 4.9.3
-    - gdal 2.2.*
+    - libgdal 2.1.*
     - g2clib 1.6.*
     - hdfeos2
     - hdfeos5
@@ -53,7 +53,7 @@ test:
   imports:
     - Nio
   commands:
-    - cd $SRC_DIR/test && nosetests
+    - cd $SRC_DIR/test && nosetests  # [not win]
     - conda inspect linkages -p $PREFIX pynio  # [not win]
     - conda inspect objects -p $PREFIX pynio  # [osx]
 


### PR DESCRIPTION
Unfortunately `fiona` is not compatible with `gdal 2.2.*` yet, so we need to pin everything to `2.1.*` is we want to install them along side with `fiona`. Note that installing the previous build number with latest `gdal` is still possible when not installing `fiona`.