### PR TITLE
drop git hash from the version for now

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "1.5.1.dev0+" + GIT_FULL_HASH[0:7] %}
+{% set version = "1.5.1.dev0" %}
 {% set commit_id = "05806a26a8676fea5832c0f270609e20df1d7276" %}
 
 package:


### PR DESCRIPTION
This should fix the upload but I'd like to solve this so we can have the short commit hash as part of the version too.

Closes #39 